### PR TITLE
Limit build workflow to main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build ZMK firmware
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- trigger artifact creation only on pushes to `main`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68407175587c8324ba5c55450386f9c0